### PR TITLE
Added missing functions, and initial support for uncaughEvents

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,21 +3,59 @@ module.exports = (function(){
 	// Import Events
 	var events = require('events');
 
+	// it's possible to enter one domain while already inside
+	// another one.  the stack is each entered domain.
+	var stack = [];
+	exports._stack = stack;
+	// the active domain is always the one that we're currently in.
+	exports.active = null;
+
+	function uncaughtException(error){
+		var domain = stack[stack.length - 1];
+		if(domain)
+			return domain.emit('error', error);
+
+		throw error;
+	}
+
+	if(typeof window !== 'undefined')
+		window.addEventListener('error', uncaughtException);
+	else
+		process.on('uncaughtException', uncaughtException);
+
 	// Export Domain
 	var domain = {};
 	domain.createDomain = domain.create = function(){
 		var d = new events.EventEmitter();
+
+		d.members = []
 
 		function emitError(e) {
 			d.emit('error', e)
 		}
 
 		d.add = function(emitter){
+			// If the domain is disposed or already added, then nothing left to do.
+			if (this._disposed || emitter.domain === this)
+				return;
+
+			// has a domain already - remove it first.
+			if (emitter.domain)
+				emitter.domain.remove(emitter);
+
+			emitter.domain = this;
+			this.members.push(emitter);
+
 			emitter.on('error', emitError);
-		}
+		};
 		d.remove = function(emitter){
+			emitter.domain = null;
+			var index = this.members.indexOf(emitter);
+			if (index !== -1)
+				this.members.splice(index, 1);
+
 			emitter.removeListener('error', emitError);
-		}
+		};
 		d.run = function(fn){
 			try {
 				fn();
@@ -26,6 +64,32 @@ module.exports = (function(){
 				this.emit('error', err);
 			}
 			return this;
+		};
+		d.bind = function(callback){
+			throw new Error('Not implemented')
+		};
+		d.intercept = function(callback){
+			throw new Error('Not implemented')
+		};
+		d.enter = function(){
+			if (this._disposed) return;
+
+			// note that this might be a no-op, but we still need
+			// to push it onto the stack so that we can pop it later.
+			exports.active = process.domain = this;
+			stack.push(this);
+		};
+		d.exit = function(){
+			// skip disposed domains, as usual, but also don't do anything if this
+			// domain is not on the stack.
+			var index = stack.lastIndexOf(this);
+			if (this._disposed || index === -1) return;
+
+			// exit all domains until this one.
+			stack.splice(index);
+
+			exports.active = stack[stack.length - 1];
+			process.domain = exports.active;
 		};
 		d.dispose = function(){
 			this.removeAllListeners();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "contributors": [
     "Benjamin Lupton <b@lupton.cc> (https://github.com/balupton)",
-    "substack (https://github.com/substack)"
+    "substack (https://github.com/substack)",
+    "Jesús Leganés Combarro 'piranna' <piranna@gmail.com> (https://github.com/piranna)"
   ],
   "bugs": {
     "url": "https://github.com/bevry/domain-browser/issues"

--- a/test.js
+++ b/test.js
@@ -19,6 +19,17 @@ joe.describe('domain-browser', function(describe,it){
 		});
 	});
 
+	it('should work on uncaught exceptions', function(done){
+		var d = domain.create();
+		d.on('error', function(err){
+			expect(err && err.message).to.eql('a thrown error');
+			done();
+		});
+		d.enter();
+			throw new Error('a thrown error');
+		d.exit();
+	});
+
 	it('should be able to add emitters', function(done){
 		var d = domain.create();
 		var emitter = new events.EventEmitter();


### PR DESCRIPTION
I've added the missing functions based on code from Node.js domains and improved the currently ones, though I'm having problems with the testing of the window.onerror event since I've not be able to make it work its Node.js counterpart, the process uncaughtEvent. If someone could be able to review it and make it work, we could be able to have fully working domains on the browser easily (I think it's mostly the only missing part...).

Also, I think this should follow better the Node.js scheme by using an explicit Domain class instead of just an EventEmitter, this could help to share code and maybe also look for what are the missing things from process so it could be used directly the Node.js domains module.
