### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,5 @@
     "prepare": "node --harmony nakefile.js prepare",
     "release": "node --harmony nakefile.js release",
     "test": "node --harmony ./test.js"
-  },
-  "dependencies": {
-    "assert-helpers": "^4.1.0"
   }
 }


### PR DESCRIPTION
assert-helpers is used only in test. It shouldn't be in production dependencies.