### PR TITLE
Async errors caught in domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = (function () {
 			d.emit('error', e)
 		}
 		
-		function wrapFns() {
+		function wrapAsyncFns() {
 			var fns
 			var oldSetImmediate
 			var oldSetTimeout = setTimeout
@@ -42,7 +42,7 @@ module.exports = (function () {
 			return fns;
 		}
 
-		function unwrapFns(fns) {
+		function unwrapAsyncFns(fns) {
 			setTimeout = fns.setTimeout
 			setInterval = fns.setInterval
 			if (fns.setImmedate) {
@@ -52,17 +52,17 @@ module.exports = (function () {
 		
 		function wrapFn(fn, args) {
 			return function() {
-				var fns = wrapFns()
+				var fns = wrapAsyncFns()
 				var hasError = true
 				try {
 					fn.apply(null, args)
 					hasError = false
 				} catch(err) {
-					unwrapFns(fns)
+					unwrapAsyncFns(fns)
 					emitError(err)
 				}
 				if (!hasError) {
-					unwrapFns(fns)
+					unwrapAsyncFns(fns)
 				}
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -53,12 +53,17 @@ module.exports = (function () {
 		function wrapFn(fn, args) {
 			return function() {
 				var fns = wrapFns()
+				var hasError = true
 				try {
 					fn.apply(null, args)
+					hasError = false
 				} catch(err) {
+					unwrapFns(fns)
 					emitError(err)
 				}
-				unwrapFns(fns)
+				if (!hasError) {
+					unwrapFns(fns)
+				}
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -103,9 +103,5 @@ module.exports = (function () {
 		}
 		return d
 	}
-	
-	function catchFn(fn) {
-		tr
-	}
 	return domain;
 }).call(this)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,54 @@ module.exports = (function () {
 		function emitError (e) {
 			d.emit('error', e)
 		}
+		
+		function wrapFns() {
+			var fns
+			var oldSetImmediate
+			var oldSetTimeout = setTimeout
+			var oldSetInterval = setInterval
+			
+			setTimeout = function setTimeoutDomain(fn, time) {
+				return oldSetTimeout(wrapFn(fn), time)
+			};
+			setInterval = function setIntervalDomain(fn, time) {
+				return oldSetInterval(wrapFn(fn), time)
+			};
+			
+			fns = {
+				setTimeout: oldSetTimeout,
+				setInterval: oldSetInterval
+			}
+			if (typeof setImmediate === 'function') {
+				oldSetImmediate = setImmediate
+				setImmediate = function setImmedate(fn) {
+					return oldSetImmediate(wrapFn(fn))
+				}
+				fns.setImmedate = oldSetImmediate
+			}
+			
+			return fns;
+		}
+
+		function unwrapFns(fns) {
+			setTimeout = fns.setTimeout
+			setInterval = fns.setInterval
+			if (fns.setImmedate) {
+				setImmediate = fns.setImmedate
+			}
+		}
+		
+		function wrapFn(fn, args) {
+			return function() {
+				var fns = wrapFns()
+				try {
+					fn.apply(null, args)
+				} catch(err) {
+					emitError(err)
+				}
+				unwrapFns(fns)
+			}
+		}
 
 		d.add = function (emitter) {
 			emitter.on('error', emitError)
@@ -23,12 +71,7 @@ module.exports = (function () {
 		d.bind = function (fn) {
 			return function () {
 				var args = Array.prototype.slice.call(arguments)
-				try {
-					fn.apply(null, args)
-				}
-				catch (err) {
-					emitError(err)
-				}
+				wrapFn(fn, args)()
 			}
 		}
 		d.intercept = function (fn) {
@@ -38,22 +81,12 @@ module.exports = (function () {
 				}
 				else {
 					var args = Array.prototype.slice.call(arguments, 1)
-					try {
-						fn.apply(null, args)
-					}
-					catch (err) {
-						emitError(err)
-					}
+					wrapFn(fn, args)();
 				}
 			}
 		}
 		d.run = function (fn) {
-			try {
-				fn()
-			}
-			catch (err) {
-				emitError(err)
-			}
+			wrapFn(fn)();
 			return this
 		}
 		d.dispose = function () {
@@ -65,5 +98,9 @@ module.exports = (function () {
 		}
 		return d
 	}
-	return domain
+	
+	function catchFn(fn) {
+		tr
+	}
+	return domain;
 }).call(this)

--- a/index.js
+++ b/index.js
@@ -22,10 +22,10 @@ module.exports = (function () {
 			
 			setTimeout = function setTimeoutDomain(fn, time) {
 				return oldSetTimeout(wrapFn(fn), time)
-			};
+			}
 			setInterval = function setIntervalDomain(fn, time) {
 				return oldSetInterval(wrapFn(fn), time)
-			};
+			}
 			
 			fns = {
 				setTimeout: oldSetTimeout,
@@ -39,7 +39,7 @@ module.exports = (function () {
 				fns.setImmedate = oldSetImmediate
 			}
 			
-			return fns;
+			return fns
 		}
 
 		function unwrapAsyncFns(fns) {
@@ -86,12 +86,12 @@ module.exports = (function () {
 				}
 				else {
 					var args = Array.prototype.slice.call(arguments, 1)
-					wrapFn(fn, args)();
+					wrapFn(fn, args)()
 				}
 			}
 		}
 		d.run = function (fn) {
-			wrapFn(fn)();
+			wrapFn(fn)()
 			return this
 		}
 		d.dispose = function () {
@@ -103,5 +103,5 @@ module.exports = (function () {
 		}
 		return d
 	}
-	return domain;
+	return domain
 }).call(this)

--- a/test.js
+++ b/test.js
@@ -76,6 +76,7 @@ joe.describe('domain-browser', function (describe, it) {
 	it('bind setTimeout error', function (done) {
 		const d = domain.create()
 		d.on('error', function (err) {
+			equal(setTimeout, currentSetTimeout)
 			equal(err && err.message, 'a thrown error', 'error message')
 			done()
 		});

--- a/test.js
+++ b/test.js
@@ -73,6 +73,96 @@ joe.describe('domain-browser', function (describe, it) {
 		})(new Error('a passed error'), 2, 3)
 	})
 
+	it('bind setTimeout error', function (done) {
+		const d = domain.create()
+		d.on('error', function (err) {
+			equal(err && err.message, 'a thrown error', 'error message')
+			done()
+		});
+		var currentSetTimeout = setTimeout;
+		d.bind(function (err, a, b) {
+			equal(err && err.message, 'a passed error', 'error message')
+			equal(a, 2, 'value of a')
+			equal(b, 3, 'value of b')
+			
+			setTimeout(function() {
+				throw new Error('a thrown error')
+			}, 5)
+			
+		})(new Error('a passed error'), 2, 3)
+		
+		// Should not affect timeout outside domain
+		equal(setTimeout, currentSetTimeout)
+	})
+
+	it('bind nested setTimeout error', function (done) {
+		const d = domain.create()
+		d.on('error', function (err) {
+			equal(err && err.message, 'a thrown error', 'error message')
+			done()
+		});
+		d.bind(function (err, a, b) {
+			equal(err && err.message, 'a passed error', 'error message')
+			equal(a, 2, 'value of a')
+			equal(b, 3, 'value of b');
+			setTimeout(function() {
+				setTimeout(function() {
+					throw new Error('a thrown error');
+				}, 10);
+			}, 10);
+		})(new Error('a passed error'), 2, 3)
+	})
+
+	it('bind setInterval error', function (done) {
+		const d = domain.create()
+		d.on('error', function (err) {
+			equal(err && err.message, 'a thrown error', 'error message')
+			done()
+		});
+		var currentSetInterval = setInterval;
+		d.bind(function (err, a, b) {
+			equal(err && err.message, 'a passed error', 'error message')
+			equal(a, 2, 'value of a')
+			equal(b, 3, 'value of b')
+
+			var index = 0;
+			var int = setInterval(function() {
+				if (index) {
+					clearInterval(int)
+					throw new Error('a thrown error')
+				}
+				index++
+			}, 5)
+
+		})(new Error('a passed error'), 2, 3)
+
+		// Should not affect timeout outside domain
+		equal(setInterval, currentSetInterval)
+	})
+
+	it('bind setImmediate error', function (done) {
+		const d = domain.create()
+		d.on('error', function (err) {
+			equal(err && err.message, 'a thrown error', 'error message')
+			done()
+		});
+		var currentSetImmediate = setImmediate;
+		d.bind(function (err, a, b) {
+			equal(err && err.message, 'a passed error', 'error message')
+			equal(a, 2, 'value of a')
+			equal(b, 3, 'value of b')
+
+			var index = 0;
+			setImmediate(function() {
+				throw new Error('a thrown error')
+			}, 5)
+
+		})(new Error('a passed error'), 2, 3)
+
+		// Should not affect timeout outside domain
+		equal(setImmediate, currentSetImmediate)
+	})
+
 	it('intercept should work', function (done) {
 		const d = domain.create()
 		let count = 0


### PR DESCRIPTION
I am using this library in the browser, but noticed it doesn't catch async errors. I saw pull request #5 that attempts to do that? I don't think that is the right approach though because that will catch all errors, not just errors in the domain.

This pull request wraps setTimeout, setInterval, setImmediate and adds tests that failed in the previous code. @balupton is this something you would consider merging or does this belong in a fork?
