### PR TITLE
Changes in .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 version: ~> 1.0
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 language: node_js
 node_js:
   - '10'


### PR DESCRIPTION
Add support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/domain-browser